### PR TITLE
I think pos == nulll logic is not rigorous enough

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ module.exports = function slice(arr, start, end) {
 };
 
 function idx(len, pos, end) {
-  if (pos == null) {
+  if (pos === null || pos === undefined) {
     pos = end || 0;
   } else if (pos < 0) {
     pos = Math.max(len + pos, 0);


### PR DESCRIPTION
In the ```pos == null ``` decision, I think the better way is to use ```===```  instead of ```==```. Second, the value of pos may also be undefined. When ```==```, ```null == undefined```  is true, but```===``` is more rigorous, because null and undefined are two different values themselves, so ```===```  can be judged as two Different values, so I mentioned such a modification.